### PR TITLE
Use the `neo4j:5-enterprise` Docker image, enable the APOC plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       retries: 5
 
   neo4j:
-    image: neo4j:5
+    image: neo4j:5-enterprise
     ports:
       - "7474:7474"
       - "7687:7687"
@@ -45,6 +45,7 @@ services:
     environment:
       - NEO4J_AUTH=neo4j/password
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_PLUGINS=["apoc"]
     healthcheck:
       test: ["CMD", "wget", "-O", "/dev/null", "http://localhost:7474"]
       interval: 5s


### PR DESCRIPTION
Closes #33.